### PR TITLE
Add cli argument `--rpc-allow-fallback-to-random-port`

### DIFF
--- a/bin/node/cli/benches/block_production.rs
+++ b/bin/node/cli/benches/block_production.rs
@@ -97,6 +97,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		rpc_max_response_size: None,
 		rpc_id_provider: None,
 		rpc_max_subs_per_conn: None,
+		rpc_allow_fallback_to_random_port: true,
 		ws_max_out_buffer_capacity: None,
 		prometheus_config: None,
 		telemetry_endpoints: None,

--- a/bin/node/cli/benches/transaction_pool.rs
+++ b/bin/node/cli/benches/transaction_pool.rs
@@ -90,6 +90,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		rpc_max_response_size: None,
 		rpc_id_provider: None,
 		rpc_max_subs_per_conn: None,
+		rpc_allow_fallback_to_random_port: true,
 		ws_max_out_buffer_capacity: None,
 		prometheus_config: None,
 		telemetry_endpoints: None,

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -116,6 +116,11 @@ pub struct RunCmd {
 	#[arg(long)]
 	pub rpc_max_subscriptions_per_connection: Option<usize>,
 
+	/// Use random port if port configured for Websocket or HTTP is already in use
+	/// Default is true.
+	#[clap(long)]
+	pub rpc_allow_fallback_to_random_port: Option<bool>,
+
 	/// Expose Prometheus exporter on all interfaces.
 	///
 	/// Default is local.
@@ -463,6 +468,10 @@ impl CliConfiguration for RunCmd {
 
 	fn rpc_max_subscriptions_per_connection(&self) -> Result<Option<usize>> {
 		Ok(self.rpc_max_subscriptions_per_connection)
+	}
+
+	fn rpc_allow_fallback_to_random_port(&self) -> Result<bool> {
+		Ok(self.rpc_allow_fallback_to_random_port.unwrap_or(true))
 	}
 
 	fn ws_max_out_buffer_capacity(&self) -> Result<Option<usize>> {

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -365,6 +365,11 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(None)
 	}
 
+	/// Use random port if port configured for Websocket or HTTP is already in use
+	fn rpc_allow_fallback_to_random_port(&self) -> Result<bool> {
+		Ok(true)
+	}
+
 	/// Get maximum WS output buffer capacity.
 	fn ws_max_out_buffer_capacity(&self) -> Result<Option<usize>> {
 		Ok(None)
@@ -544,6 +549,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			rpc_max_response_size: self.rpc_max_response_size()?,
 			rpc_id_provider: None,
 			rpc_max_subs_per_conn: self.rpc_max_subscriptions_per_connection()?,
+			rpc_allow_fallback_to_random_port: self.rpc_allow_fallback_to_random_port()?,
 			ws_max_out_buffer_capacity: self.ws_max_out_buffer_capacity()?,
 			prometheus_config: self
 				.prometheus_config(DCV::prometheus_listen_port(), &chain_spec)?,

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -113,6 +113,8 @@ pub struct Configuration {
 	///
 	/// Default: 1024.
 	pub rpc_max_subs_per_conn: Option<usize>,
+	/// Use random port if port configured for Websocket or HTTP is already in use
+	pub rpc_allow_fallback_to_random_port: bool,
 	/// Maximum size of the output buffer capacity for websocket connections.
 	pub ws_max_out_buffer_capacity: Option<usize>,
 	/// Prometheus endpoint configuration. `None` if disabled.

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -345,16 +345,20 @@ where
 	let ws_addr = config
 		.rpc_ws
 		.unwrap_or_else(|| "127.0.0.1:9944".parse().expect("valid sockaddr; qed"));
-	let ws_addr2 = random_port(ws_addr);
+	let ws_addrs = [ws_addr, random_port(ws_addr)];
+	let ws_addrs =
+		if config.rpc_allow_fallback_to_random_port { &ws_addrs[..] } else { &ws_addrs[..1] };
+
 	let http_addr = config
 		.rpc_http
 		.unwrap_or_else(|| "127.0.0.1:9933".parse().expect("valid sockaddr; qed"));
-	let http_addr2 = random_port(http_addr);
+	let http_addrs = [http_addr, random_port(http_addr)];
+	let http_addrs =
+		if config.rpc_allow_fallback_to_random_port { &http_addrs[..] } else { &http_addrs[..1] };
 
 	let metrics = sc_rpc_server::RpcMetrics::new(config.prometheus_registry())?;
-
 	let http_fut = sc_rpc_server::start_http(
-		[http_addr, http_addr2],
+		http_addrs,
 		config.rpc_cors.as_ref(),
 		max_request_size,
 		http_max_response_size,
@@ -371,7 +375,7 @@ where
 	};
 
 	let ws_fut = sc_rpc_server::start_ws(
-		[ws_addr, ws_addr2],
+		ws_addrs,
 		config.rpc_cors.as_ref(),
 		ws_config,
 		metrics,

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -250,6 +250,7 @@ fn node_config<
 		rpc_max_response_size: None,
 		rpc_id_provider: None,
 		rpc_max_subs_per_conn: None,
+		rpc_allow_fallback_to_random_port: true,
 		ws_max_out_buffer_capacity: None,
 		prometheus_config: None,
 		telemetry_endpoints: None,


### PR DESCRIPTION
Currently when Substrate node is starting it binds to configured JSON-RPC HTTP port and WS port. If this port is already in use then it binds to a random port instead. Sometimes this behavior creates problems. For example during development if a developer for some reason forgets to stop an old version of a node and starts a new version then all tests will run against the old version. Such an issue could be hard to diagnose.
This PR fixes the issue by making this behavior configurable and adding cli argument `--rpc-allow-fallback-to-random-port`. By default if the argument isn't used or if `--rpc-allow-fallback-to-random-port=true` is added then node behaves as before. But if  `--rpc-allow-fallback-to-random-port=false` is added then a node will panic instead of  binding to random port with `Address is already in use` error.