### PR TITLE
Feature/batch call filter

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -249,6 +249,7 @@ impl pallet_utility::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type PalletsOrigin = OriginCaller;
 	type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
+	type CallFilter = Everything;
 }
 
 parameter_types! {

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -40,6 +40,8 @@ use frame_support::{
 	traits::{
 		ConstU32, ConstU64, Contains, Currency, ExistenceRequirement, LockableCurrency, OnIdle,
 		OnInitialize, WithdrawReasons,
+		ConstU32, ConstU64, Contains, Currency, Everything, ExistenceRequirement, Get,
+		LockableCurrency, OnIdle, OnInitialize, WithdrawReasons,
 	},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
@@ -337,6 +339,7 @@ impl pallet_utility::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type PalletsOrigin = OriginCaller;
 	type WeightInfo = ();
+	type CallFilter = Everything;
 }
 
 impl pallet_proxy::Config for Test {

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -26,7 +26,7 @@ use codec::{Decode, Encode};
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::DispatchError,
-	traits::{ConstU32, ConstU64, Contains},
+	traits::{ConstU32, ConstU64, Contains, Everything},
 	RuntimeDebug,
 };
 use sp_core::H256;
@@ -98,6 +98,7 @@ impl pallet_utility::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type PalletsOrigin = OriginCaller;
 	type WeightInfo = ();
+	type CallFilter = Everything;
 }
 
 #[derive(

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -29,7 +29,7 @@ use frame_support::{
 	assert_err_ignore_postinfo, assert_noop, assert_ok,
 	pallet_prelude::GenesisBuild,
 	parameter_types,
-	traits::{ConstU32, ConstU64, OnInitialize},
+	traits::{ConstU32, ConstU64, Everything, OnInitialize},
 	PalletId,
 };
 
@@ -101,6 +101,7 @@ impl pallet_utility::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type PalletsOrigin = OriginCaller;
 	type WeightInfo = ();
+	type CallFilter = Everything;
 }
 
 parameter_types! {

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -286,7 +286,7 @@ pub mod pallet {
 			origin.set_caller_from(frame_system::RawOrigin::Signed(pseudonym));
 			let info = call.get_dispatch_info();
 
-			let result = Self::dispatch_filtered(origin, *call);
+			let result = call.dispatch(origin);
 			// Always take into account the base weight of this call.
 			let mut weight = T::WeightInfo::as_derivative()
 				.saturating_add(T::DbWeight::get().reads_writes(1, 1));

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -173,8 +173,9 @@ pub mod pallet {
 		/// - `calls`: The calls to be dispatched from the same origin. The number of call must not
 		///   exceed the constant: `batched_calls_limit` (available in constant metadata).
 		///
-		/// If origin is root then the calls are dispatched without checking origin filter. (This
-		/// includes bypassing `frame_system::Config::BaseCallFilter`).
+		/// If the source is root, then calls are sent without checking the origin and call filters.
+		/// (This involves bypassing `frame_system::Config::BaseCallFilter` and
+		/// `Config::CallFilter`).
 		///
 		/// ## Complexity
 		/// - O(C) where C is the number of calls to be batched.
@@ -306,8 +307,9 @@ pub mod pallet {
 		/// - `calls`: The calls to be dispatched from the same origin. The number of call must not
 		///   exceed the constant: `batched_calls_limit` (available in constant metadata).
 		///
-		/// If origin is root then the calls are dispatched without checking origin filter. (This
-		/// includes bypassing `frame_system::Config::BaseCallFilter`).
+		/// If the source is root, then calls are sent without checking the origin and call filters.
+		/// (This involves bypassing `frame_system::Config::BaseCallFilter` and
+		/// `Config::CallFilter`).
 		///
 		/// ## Complexity
 		/// - O(C) where C is the number of calls to be batched.
@@ -418,8 +420,9 @@ pub mod pallet {
 		/// - `calls`: The calls to be dispatched from the same origin. The number of call must not
 		///   exceed the constant: `batched_calls_limit` (available in constant metadata).
 		///
-		/// If origin is root then the calls are dispatch without checking origin filter. (This
-		/// includes bypassing `frame_system::Config::BaseCallFilter`).
+		/// If the source is root, then calls are sent without checking the origin and call filters.
+		/// (This involves bypassing `frame_system::Config::BaseCallFilter` and
+		/// `Config::CallFilter`).
 		///
 		/// ## Complexity
 		/// - O(C) where C is the number of calls to be batched.

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -23,7 +23,7 @@ use super::*;
 
 use crate as utility;
 use frame_support::{
-	assert_err, assert_err_ignore_postinfo, assert_noop, assert_ok,
+	assert_err_ignore_postinfo, assert_noop, assert_ok,
 	dispatch::{DispatchError, DispatchErrorWithPostInfo, Dispatchable, Pays},
 	error::BadOrigin,
 	parameter_types, storage,

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -23,7 +23,7 @@ use super::*;
 
 use crate as utility;
 use frame_support::{
-	assert_err_ignore_postinfo, assert_noop, assert_ok,
+	assert_err, assert_err_ignore_postinfo, assert_noop, assert_ok,
 	dispatch::{DispatchError, DispatchErrorWithPostInfo, Dispatchable, Pays},
 	error::BadOrigin,
 	parameter_types, storage,
@@ -778,6 +778,30 @@ fn batch_all_does_not_nest() {
 		);
 		assert_eq!(Balances::free_balance(1), 10);
 		assert_eq!(Balances::free_balance(2), 10);
+	});
+}
+
+#[test]
+fn batch_all_with_signed_call_filters() {
+	new_test_ext().execute_with(|| {
+		assert_err_ignore_postinfo!(
+			Utility::batch_all(
+				RuntimeOrigin::signed(1),
+				vec![RuntimeCall::Example(example::Call::not_batchable { arg: 0 })]
+			),
+			DispatchError::from(frame_system::Error::<Test>::CallFiltered)
+		);
+	});
+}
+
+#[test]
+fn batch_all_with_root_call_filters() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Utility::batch_all(
+			RuntimeOrigin::root(),
+			vec![RuntimeCall::Example(example::Call::not_batchable { arg: 0 })]
+		),);
+		System::assert_last_event(utility::Event::BatchCompleted.into());
 	});
 }
 

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -419,20 +419,6 @@ fn as_derivative_basic_filters() {
 }
 
 #[test]
-fn as_derivative_call_filters() {
-	new_test_ext().execute_with(|| {
-		assert_err_ignore_postinfo!(
-			Utility::as_derivative(
-				RuntimeOrigin::signed(1),
-				1,
-				Box::new(RuntimeCall::Example(example::Call::not_batchable { arg: 0 })),
-			),
-			DispatchError::from(frame_system::Error::<Test>::CallFiltered),
-		);
-	});
-}
-
-#[test]
 fn batch_with_root_works() {
 	new_test_ext().execute_with(|| {
 		let k = b"a".to_vec();

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -853,6 +853,28 @@ fn force_batch_works() {
 }
 
 #[test]
+fn force_batch_with_signed_call_filters() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Utility::force_batch(
+			RuntimeOrigin::signed(1),
+			vec![RuntimeCall::Example(example::Call::not_batchable { arg: 0 })]
+		),);
+		System::assert_last_event(utility::Event::BatchCompletedWithErrors.into());
+	});
+}
+
+#[test]
+fn force_batch_with_root_call_filters() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Utility::force_batch(
+			RuntimeOrigin::root(),
+			vec![RuntimeCall::Example(example::Call::not_batchable { arg: 0 })]
+		),);
+		System::assert_last_event(utility::Event::BatchCompleted.into());
+	});
+}
+
+#[test]
 fn none_origin_does_not_work() {
 	new_test_ext().execute_with(|| {
 		assert_noop!(Utility::force_batch(RuntimeOrigin::none(), vec![]), BadOrigin);

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -402,7 +402,7 @@ fn as_derivative_handles_weight_refund() {
 }
 
 #[test]
-fn as_derivative_filters() {
+fn as_derivative_basic_filters() {
 	new_test_ext().execute_with(|| {
 		assert_err_ignore_postinfo!(
 			Utility::as_derivative(
@@ -412,6 +412,20 @@ fn as_derivative_filters() {
 					dest: 2,
 					value: 1
 				})),
+			),
+			DispatchError::from(frame_system::Error::<Test>::CallFiltered),
+		);
+	});
+}
+
+#[test]
+fn as_derivative_call_filters() {
+	new_test_ext().execute_with(|| {
+		assert_err_ignore_postinfo!(
+			Utility::as_derivative(
+				RuntimeOrigin::signed(1),
+				1,
+				Box::new(RuntimeCall::Example(example::Call::not_batchable { arg: 0 })),
 			),
 			DispatchError::from(frame_system::Error::<Test>::CallFiltered),
 		);


### PR DESCRIPTION
## Description
Adding CallFilter to pallet-utility.

## Motivation
The current form of the pallet uses [frame_system::Config::BaseCallFilter](https://paritytech.github.io/substrate/master/pallet_contracts/chain_extension/trait.SysConfig.html#associatedtype.BaseCallFilter), which does not allow to disable calls that should not be used in this particular pallet.

## Behavior
This PR adds call filtering at the pallet level. Filtering rules are similar to `frame_system::Config::BaseCallFilter`:

- For Root Origin, filtering is disabled.
- For Signed Origin, the [frame_support::traits::Contains::contains](https://paritytech.github.io/substrate/master/frame_support/traits/trait.Contains.html#tymethod.contains) method is used. If the result is true, then [sp_runtime::traits::Dispatchable::dispatch](https://paritytech.github.io/substrate/master/sp_runtime/traits/trait.Dispatchable.html#tymethod.dispatch) is called, otherwise the error [frame_system::Error::CallFiltered](https://paritytech.github.io/substrate/master/frame_system/pallet/enum.Error.html#variant.CallFiltered) is returned.

